### PR TITLE
Fixing permissions on github workflow for deploying documentation by version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 jobs:
@@ -43,8 +43,6 @@ jobs:
     name: Publish documentation
     needs: [build]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,6 +43,8 @@ jobs:
     name: Publish documentation
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## This PR proposes the following changes
- Updates `contents` permission to `write` to allow github bot to push branch `gh-pages` to `origin` when updating documentation.

<!-- If applicable Issue Number: Closes #N/A -->

### PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
