### PR TITLE
Add dagster deployment option using helm chart on local stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.pyc
+
 # Local .terraform directories
 **/.terraform/*
 

--- a/src/mlinfra/modules/applications/local/orchestrator/dagster/dagster.yaml
+++ b/src/mlinfra/modules/applications/local/orchestrator/dagster/dagster.yaml
@@ -1,0 +1,9 @@
+inputs:
+  - name: dagster_chart_version
+    user_facing: true
+    description: Version of the Dagster Helm chart to use-
+    default: "1.8.13"
+outputs:
+  - name: dagster_endpoint
+    description: Dagster access endpoint.
+    export: true

--- a/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/main.tf
+++ b/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/main.tf
@@ -1,0 +1,22 @@
+locals {
+  dagster_helmchart_set = [{
+    name  = "ingress.dagsterWebserver.host"
+    value = var.dagster_endpoint
+    type  = "auto"
+    }
+  ]
+}
+
+module "dagster_helmchart" {
+  source           = "../../../../../local/helm_chart"
+  name             = "dagster"
+  namespace        = "dagster"
+  create_namespace = true
+  repository       = "https://dagster-io.github.io/helm"
+  chart            = "dagster"
+  chart_version    = var.dagster_chart_version
+  values = templatefile("${path.module}/values.yaml", {
+    resources = jsonencode(var.resources)
+  })
+  set = local.dagster_helmchart_set
+}

--- a/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/outputs.tf
+++ b/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/outputs.tf
@@ -1,0 +1,4 @@
+output "dagster_endpoint" {
+  value       = var.dagster_endpoint
+  description = ""
+}

--- a/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/values.yaml
+++ b/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/values.yaml
@@ -1,0 +1,1 @@
+resources: ${resources}

--- a/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/variables.tf
+++ b/src/mlinfra/modules/applications/local/orchestrator/dagster/tf_module/variables.tf
@@ -1,0 +1,34 @@
+variable "dagster_chart_version" {
+  type        = string
+  description = "Version of the Dagster Helm chart to use"
+  default     = "1.8.13"
+}
+
+variable "resources" {
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  description = "Resource requests and limits for Dagster pods"
+  default = {
+    requests = {
+      cpu    = "100m"
+      memory = "128Mi"
+    }
+    limits = {
+      cpu    = "500m"
+      memory = "512Mi"
+    }
+  }
+}
+
+variable "dagster_endpoint" {
+  type    = string
+  default = "dagster.localhost"
+}


### PR DESCRIPTION
## This PR proposes the following changes
- Add dagster orchestrator tool option for local deployment
- Add `*.pyc` in `.gitignore` 

Closes #93 

### PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
