### PR TITLE
fix: Set attestation as false in pypi release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -91,3 +91,5 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false


### PR DESCRIPTION
## This PR proposes the following changes
- Set attestation as false in pypi release which is turned on by default in [latest pypi package release mechanism](https://github.com/pypa/gh-action-pypi-publish/issues/283).

<!-- If applicable Issue Number: Closes #N/A -->

### PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
